### PR TITLE
Add saved gym persistence and owner drawer

### DIFF
--- a/components/SavedGymsDrawer.tsx
+++ b/components/SavedGymsDrawer.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import type { SavedGym } from '../services/savedGyms';
+
+export type SavedGymsDrawerProps = {
+  isOpen: boolean;
+  gyms: SavedGym[];
+  defaultGymSlug: string | null;
+  onClose: () => void;
+  onSelectGym: (gym: SavedGym) => void;
+  onSetDefault: (gym: SavedGym) => void;
+  onRemove: (gym: SavedGym) => void;
+};
+
+const SavedGymsDrawer: React.FC<SavedGymsDrawerProps> = ({
+  isOpen,
+  gyms,
+  defaultGymSlug,
+  onClose,
+  onSelectGym,
+  onSetDefault,
+  onRemove,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0 bg-slate-950/80 backdrop-blur-sm"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      <aside className="absolute right-0 top-0 h-full w-full max-w-md bg-slate-900/95 border-l border-white/10 shadow-[0_20px_80px_rgba(15,23,42,0.6)]">
+        <div className="flex items-center justify-between px-6 py-5 border-b border-white/10">
+          <div>
+            <p className="text-xs uppercase tracking-[0.4em] text-indigo-200/60">Owners</p>
+            <h2 className="text-xl font-semibold text-white">Saved gyms</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-white/10 px-3 py-1 text-xs font-semibold text-slate-300 hover:border-white/40 hover:text-white"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="h-[calc(100%-92px)] overflow-y-auto px-6 py-6 space-y-4">
+          {gyms.length === 0 ? (
+            <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5 text-sm text-slate-400">
+              You haven’t saved any gyms yet. Load a schedule to add it here for quick switching.
+            </div>
+          ) : (
+            gyms.map((gym) => {
+              const isDefault = gym.slug === defaultGymSlug;
+              const lastUsedDate = new Date(gym.lastUsedAt);
+              const lastUsedLabel = Number.isNaN(lastUsedDate.getTime())
+                ? 'recently'
+                : lastUsedDate.toLocaleString();
+              return (
+                <div
+                  key={gym.slug}
+                  className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 space-y-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-white">{gym.name}</p>
+                      <p className="text-xs text-slate-400">Slug: {gym.slug}</p>
+                      <p className="text-xs text-slate-500 mt-1">Last used {lastUsedLabel}</p>
+                    </div>
+                    {isDefault && (
+                      <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-200 border border-emerald-400/40">
+                        Default
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onSelectGym(gym)}
+                      className="rounded-full bg-indigo-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-400"
+                    >
+                      Load this gym
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onSetDefault(gym)}
+                      className="rounded-full border border-white/20 px-3 py-1.5 text-xs font-semibold text-slate-200 hover:border-white/50"
+                      disabled={isDefault}
+                    >
+                      {isDefault ? 'Default selected' : 'Set as default'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onRemove(gym)}
+                      className="rounded-full border border-rose-500/40 px-3 py-1.5 text-xs font-semibold text-rose-200 hover:border-rose-400 hover:text-rose-100"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+};
+
+export default SavedGymsDrawer;

--- a/services/savedGyms.ts
+++ b/services/savedGyms.ts
@@ -1,0 +1,126 @@
+import { slugifyLocation } from '../utils/slugify';
+
+export type SavedGym = {
+  name: string;
+  slug: string;
+  radius: number;
+  lastUsedAt: string;
+};
+
+export type SavedGymsState = {
+  gyms: SavedGym[];
+  defaultGymSlug: string | null;
+};
+
+const STORAGE_KEY = 'savedGymsState:v1';
+
+const emptyState: SavedGymsState = { gyms: [], defaultGymSlug: null };
+
+const isBrowser = () => typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+
+const normalizeGym = (gym: SavedGym): SavedGym => {
+  const radiusValue = Number((gym as any).radius);
+  const safeRadius = Number.isFinite(radiusValue) && radiusValue > 0 ? radiusValue : 5;
+  return {
+    ...gym,
+    slug: gym.slug || slugifyLocation(gym.name),
+    radius: safeRadius,
+    lastUsedAt: gym.lastUsedAt || new Date().toISOString(),
+  };
+};
+
+const readState = (): SavedGymsState => {
+  if (!isBrowser()) {
+    return emptyState;
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return emptyState;
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return emptyState;
+    }
+    const gymsArray: any[] = Array.isArray(parsed.gyms) ? parsed.gyms : [];
+    const gyms: SavedGym[] = gymsArray
+      .map((gym) => normalizeGym(gym))
+      .sort((a, b) => new Date(b.lastUsedAt).getTime() - new Date(a.lastUsedAt).getTime());
+    const defaultGymSlug = typeof parsed.defaultGymSlug === 'string' ? parsed.defaultGymSlug : null;
+    return { gyms, defaultGymSlug };
+  } catch (error) {
+    console.error('Failed to read saved gyms from localStorage:', error);
+    return emptyState;
+  }
+};
+
+const persistState = (state: SavedGymsState): SavedGymsState => {
+  if (!isBrowser()) {
+    return state;
+  }
+  const payload: SavedGymsState = {
+    gyms: state.gyms.map((gym) => normalizeGym(gym)),
+    defaultGymSlug: state.defaultGymSlug,
+  };
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.error('Failed to persist saved gyms to localStorage:', error);
+  }
+  return payload;
+};
+
+export const loadSavedGyms = (): SavedGymsState => readState();
+
+export const saveGymRecord = (
+  gym: Omit<SavedGym, 'lastUsedAt'> & { lastUsedAt?: string },
+  options: { setAsDefault?: boolean } = {},
+): SavedGymsState => {
+  const state = readState();
+  const existingIndex = state.gyms.findIndex((item) => item.slug === gym.slug);
+  const now = new Date().toISOString();
+  const nextGym = normalizeGym({ ...gym, lastUsedAt: gym.lastUsedAt || now });
+  let gyms: SavedGym[];
+
+  if (existingIndex >= 0) {
+    gyms = [...state.gyms];
+    gyms[existingIndex] = { ...state.gyms[existingIndex], ...nextGym, lastUsedAt: now };
+  } else {
+    gyms = [...state.gyms, nextGym];
+  }
+
+  gyms.sort((a, b) => new Date(b.lastUsedAt).getTime() - new Date(a.lastUsedAt).getTime());
+
+  const defaultGymSlug = options.setAsDefault ? nextGym.slug : state.defaultGymSlug ?? nextGym.slug;
+
+  return persistState({ gyms, defaultGymSlug });
+};
+
+export const touchSavedGym = (slug: string): SavedGymsState => {
+  const state = readState();
+  const gym = state.gyms.find((item) => item.slug === slug);
+  if (!gym) {
+    return state;
+  }
+  const updatedGym: SavedGym = { ...gym, lastUsedAt: new Date().toISOString() };
+  const gyms = state.gyms
+    .map((item) => (item.slug === slug ? updatedGym : item))
+    .sort((a, b) => new Date(b.lastUsedAt).getTime() - new Date(a.lastUsedAt).getTime());
+  return persistState({ gyms, defaultGymSlug: state.defaultGymSlug });
+};
+
+export const removeSavedGym = (slug: string): SavedGymsState => {
+  const state = readState();
+  const gyms = state.gyms.filter((item) => item.slug !== slug);
+  const defaultGymSlug = state.defaultGymSlug === slug ? (gyms[0]?.slug ?? null) : state.defaultGymSlug;
+  return persistState({ gyms, defaultGymSlug });
+};
+
+export const setDefaultGym = (slug: string | null): SavedGymsState => {
+  const state = readState();
+  if (slug && !state.gyms.some((gym) => gym.slug === slug)) {
+    return state;
+  }
+  return persistState({ gyms: state.gyms, defaultGymSlug: slug });
+};
+


### PR DESCRIPTION
## Summary
- persist saved gyms in local storage and auto-load the default gym on return visits
- prompt users to save a gym after a successful fetch and surface messages about saved gyms
- add an owner drawer for managing multiple saved gyms and reusable saved-gym utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fda16c5cf883278bec5c46e3e28fc0