### PR TITLE
Add Clerk authentication gates to Studiogram

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,18 +1,80 @@
 import React from 'react';
-import { HashRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route, Outlet } from 'react-router-dom';
+import { SignedIn, SignedOut, SignIn, SignUp, UserButton, RedirectToSignIn } from '@clerk/clerk-react';
 import HomePage from './pages/HomePage';
 import RenderPage from './pages/RenderPage';
 import IngestPage from './pages/IngestPage';
 import GymFinderPage from './pages/GymFinderPage';
 
+const AuthenticatedLayout: React.FC = () => {
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-900 text-white">
+      <header className="flex items-center justify-between border-b border-neutral-800 bg-neutral-950/80 px-6 py-4">
+        <h1 className="text-lg font-semibold tracking-tight">Studiogram</h1>
+        <UserButton afterSignOutUrl="/sign-in" appearance={{ elements: { avatarBox: 'h-10 w-10' } }} />
+      </header>
+      <main className="flex-1">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+const AuthPageShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-950 px-4">
+      <div className="w-full max-w-md rounded-3xl border border-neutral-800 bg-neutral-900/70 p-8 text-white shadow-xl shadow-black/30">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+const ProtectedRoute: React.FC = () => {
+  return (
+    <>
+      <SignedIn>
+        <AuthenticatedLayout />
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn routing="hash" redirectUrl="/sign-in" />
+      </SignedOut>
+    </>
+  );
+};
+
 const App: React.FC = () => {
   return (
     <HashRouter>
       <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/render" element={<RenderPage />} />
-        <Route path="/ingest" element={<IngestPage />} />
-        <Route path="/gym-finder" element={<GymFinderPage />} />
+        <Route
+          path="/sign-in"
+          element={
+            <SignedOut>
+              <AuthPageShell>
+                <h2 className="mb-6 text-center text-2xl font-semibold tracking-tight">Sign in to Studiogram</h2>
+                <SignIn routing="hash" signUpUrl="/sign-up" afterSignInUrl="/" />
+              </AuthPageShell>
+            </SignedOut>
+          }
+        />
+        <Route
+          path="/sign-up"
+          element={
+            <SignedOut>
+              <AuthPageShell>
+                <h2 className="mb-6 text-center text-2xl font-semibold tracking-tight">Create your Studiogram account</h2>
+                <SignUp routing="hash" signInUrl="/sign-in" afterSignUpUrl="/" />
+              </AuthPageShell>
+            </SignedOut>
+          }
+        />
+        <Route path="/" element={<ProtectedRoute />}>
+          <Route index element={<HomePage />} />
+          <Route path="render" element={<RenderPage />} />
+          <Route path="ingest" element={<IngestPage />} />
+          <Route path="gym-finder" element={<GymFinderPage />} />
+        </Route>
       </Routes>
     </HashRouter>
   );

--- a/index.tsx
+++ b/index.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { ClerkProvider } from '@clerk/clerk-react';
 import App from './App';
 
 const rootElement = document.getElementById('root');
@@ -9,8 +10,19 @@ if (!rootElement) {
 }
 
 const root = ReactDOM.createRoot(rootElement);
+
+const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+if (!clerkPublishableKey) {
+  throw new Error(
+    'Missing Clerk publishable key. Please set VITE_CLERK_PUBLISHABLE_KEY in your environment.'
+  );
+}
+
 root.render(
   <React.StrictMode>
-    <App />
+    <ClerkProvider publishableKey={clerkPublishableKey}>
+      <App />
+    </ClerkProvider>
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "instagram-story-schedule-generator",
       "version": "0.0.0",
       "dependencies": {
+        "@clerk/clerk-react": "^5.53.3",
         "firebase": "^12.3.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -301,6 +302,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.53.3",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.53.3.tgz",
+      "integrity": "sha512-7bEaJox6TzVhUSX6PjOuKpu6KPFT92bdeFSm8gtcA5ix4ce1WE0pC6K7mWdNZXxpLWmBbbqqsOuQSBFVIcC0hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.28.3",
+        "@clerk/types": "^4.95.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.28.3",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.28.3.tgz",
+      "integrity": "sha512-IjuEHf2faKohv7Q4Q/C1P7bvXonbatuGwTu2ZUQ5wnULafHRpT6GfR82bhk/OaxTZ0CI+sPzHr7yoC3Kp8Ho1g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "^4.95.1",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.95.1",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.95.1.tgz",
+      "integrity": "sha512-YZ7fiWS1IL7zl6o3azw+9HRO1keeEhaTieqSpwlesHASp3dE8EIB6WwSkGlcGOWRZyrOgisoBRDERP6tdzprZA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2765,6 +2826,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2781,6 +2848,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3484,6 +3560,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3580,6 +3662,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -4322,6 +4413,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4376,6 +4473,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tar": {
@@ -4598,6 +4708,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@clerk/clerk-react": "^5.53.3",
     "firebase": "^12.3.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- wrap the React app with ClerkProvider and require the configured publishable key
- add dedicated sign-in/sign-up routes and protect existing pages behind Clerk authentication
- add the Clerk React SDK dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe1fabbabc8327a5b887795feca01c