### PR TITLE
Add Femme Friday schedule template module

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,10 @@
 import type { AppSettings, Schedule, Style, ColorPalette } from './types';
-import { CLASSIC_TEMPLATE_BASE_STYLE, CLASSIC_TEMPLATE_ID } from './templates';
+import {
+  CLASSIC_TEMPLATE_BASE_STYLE,
+  CLASSIC_TEMPLATE_ID,
+  FEMME_FRIDAY_TEMPLATE_BASE_STYLE,
+  FEMME_FRIDAY_TEMPLATE_ID,
+} from './templates';
 
 // --- Base styles to reduce repetition ---
 // FIX: Added `as const` to properties with string literal union types (`logoPosition`,
@@ -434,6 +439,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   activeTemplateId: CLASSIC_TEMPLATE_ID,
   configs: {
     [CLASSIC_TEMPLATE_ID]: { ...CLASSIC_TEMPLATE_BASE_STYLE },
+    [FEMME_FRIDAY_TEMPLATE_ID]: { ...FEMME_FRIDAY_TEMPLATE_BASE_STYLE },
   },
 };
 

--- a/lib/templates/definitions/femmeFriday.ts
+++ b/lib/templates/definitions/femmeFriday.ts
@@ -1,0 +1,102 @@
+import {
+  DEFAULT_VISIBLE_ELEMENTS,
+  DEFAULT_HIDDEN_ELEMENTS,
+  ELEMENT_ORDER,
+  buildInitialElementStyles,
+} from '../../../components/editor/contentElements';
+import { DEFAULT_SMART_SPACING } from '../../../components/editor/smartTextSizing';
+import type { TemplateDefinition } from '../registry';
+import {
+  DEFAULT_CONTENT_TAB_CONTROLS,
+  DEFAULT_LAYOUT_TAB_CONTROLS,
+  DEFAULT_STYLE_TAB_CONTROLS,
+} from '../editorConfig';
+import {
+  FEMME_FRIDAY_TEMPLATE_BASE_STYLE,
+  FEMME_FRIDAY_TEMPLATE_ID,
+  FEMME_FRIDAY_TEMPLATE_METADATA,
+} from '../../../templates';
+
+const createFemmeFridayElementStyles = () => {
+  const styles = buildInitialElementStyles();
+  styles.heading = {
+    ...styles.heading,
+    color: '#FDF2F8',
+    letterSpacing: -0.8,
+  };
+  styles.subtitle = {
+    ...styles.subtitle,
+    color: '#FBCFE8',
+    fontWeight: 600,
+  };
+  styles.scheduleDate = {
+    ...styles.scheduleDate,
+    color: '#F472B6',
+    letterSpacing: 2.4,
+  };
+  styles.className = {
+    ...styles.className,
+    color: '#FDF2F8',
+    fontWeight: 700,
+  };
+  styles.instructor = {
+    ...styles.instructor,
+    color: '#F9A8D4',
+    fontWeight: 500,
+  };
+  styles.time = {
+    ...styles.time,
+    color: '#FDF2F8',
+    fontWeight: 600,
+    letterSpacing: 0.6,
+  };
+  styles.location = {
+    ...styles.location,
+    color: '#FCE7F3',
+  };
+  styles.duration = {
+    ...styles.duration,
+    color: '#F5D0FE',
+  };
+  styles.description = {
+    ...styles.description,
+    color: '#F5D0FE',
+  };
+  styles.footer = {
+    ...styles.footer,
+    color: '#F5D0FE',
+    letterSpacing: 0.4,
+  };
+  return styles;
+};
+
+const createFemmeFridayTemplateDefinition = (): TemplateDefinition => ({
+  id: FEMME_FRIDAY_TEMPLATE_ID,
+  metadata: {
+    ...FEMME_FRIDAY_TEMPLATE_METADATA,
+    tags: FEMME_FRIDAY_TEMPLATE_METADATA.tags ? [...FEMME_FRIDAY_TEMPLATE_METADATA.tags] : undefined,
+  },
+  defaults: {
+    createStyle: () => ({ ...FEMME_FRIDAY_TEMPLATE_BASE_STYLE }),
+    createVisibleElements: () => [...DEFAULT_VISIBLE_ELEMENTS],
+    createHiddenElements: () => [...DEFAULT_HIDDEN_ELEMENTS],
+    createElementOrder: () => [...ELEMENT_ORDER],
+    createElementStyles: () => createFemmeFridayElementStyles(),
+    createSmartSpacing: () => ({
+      ...DEFAULT_SMART_SPACING,
+      heroGap: DEFAULT_SMART_SPACING.heroGap * 1.05,
+      scheduleGap: DEFAULT_SMART_SPACING.scheduleGap * 1.12,
+      cardPadding: DEFAULT_SMART_SPACING.cardPadding * 1.08,
+      footerGap: DEFAULT_SMART_SPACING.footerGap * 1.05,
+      timePadding: DEFAULT_SMART_SPACING.timePadding * 1.08,
+    }),
+  },
+  editor: {
+    styleTab: DEFAULT_STYLE_TAB_CONTROLS,
+    contentTab: DEFAULT_CONTENT_TAB_CONTROLS,
+    layoutTab: DEFAULT_LAYOUT_TAB_CONTROLS,
+  },
+});
+
+export const FEMME_FRIDAY_TEMPLATE_DEFINITION = createFemmeFridayTemplateDefinition();
+export { FEMME_FRIDAY_TEMPLATE_ID } from '../../../templates';

--- a/lib/templates/index.ts
+++ b/lib/templates/index.ts
@@ -1,4 +1,5 @@
 import { CLASSIC_TEMPLATE_DEFINITION } from './definitions/classic';
+import { FEMME_FRIDAY_TEMPLATE_DEFINITION } from './definitions/femmeFriday';
 import {
   registerTemplate,
   setFallbackTemplateId,
@@ -18,6 +19,10 @@ import {
 
 if (!isTemplateRegistered(CLASSIC_TEMPLATE_DEFINITION.id)) {
   registerTemplate(CLASSIC_TEMPLATE_DEFINITION, { fallback: true });
+}
+
+if (!isTemplateRegistered(FEMME_FRIDAY_TEMPLATE_DEFINITION.id)) {
+  registerTemplate(FEMME_FRIDAY_TEMPLATE_DEFINITION);
 }
 
 export {
@@ -41,3 +46,4 @@ export type {
 };
 
 export { CLASSIC_TEMPLATE_DEFINITION, CLASSIC_TEMPLATE_ID } from './definitions/classic';
+export { FEMME_FRIDAY_TEMPLATE_DEFINITION, FEMME_FRIDAY_TEMPLATE_ID } from './definitions/femmeFriday';

--- a/templates/__tests__/modules.test.ts
+++ b/templates/__tests__/modules.test.ts
@@ -4,23 +4,42 @@ import {
   TEMPLATE_GALLERY_CATEGORIES,
   CLASSIC_TEMPLATE_ID,
   CLASSIC_TEMPLATE_METADATA,
+  FEMME_FRIDAY_TEMPLATE_ID,
+  FEMME_FRIDAY_TEMPLATE_METADATA,
 } from '../../templates';
-import { CLASSIC_TEMPLATE_DEFINITION } from '../../lib/templates';
+import { CLASSIC_TEMPLATE_DEFINITION, FEMME_FRIDAY_TEMPLATE_DEFINITION } from '../../lib/templates';
+
+const MODULE_EXPECTATIONS = [
+  {
+    id: CLASSIC_TEMPLATE_ID,
+    metadata: CLASSIC_TEMPLATE_METADATA,
+    definition: CLASSIC_TEMPLATE_DEFINITION,
+  },
+  {
+    id: FEMME_FRIDAY_TEMPLATE_ID,
+    metadata: FEMME_FRIDAY_TEMPLATE_METADATA,
+    definition: FEMME_FRIDAY_TEMPLATE_DEFINITION,
+  },
+] as const;
 
 describe('template modules', () => {
-  it('includes the classic template module with matching metadata', () => {
-    const classicModule = TEMPLATE_MODULES.find((module) => module.id === CLASSIC_TEMPLATE_ID);
-    expect(classicModule).toBeDefined();
-    expect(classicModule?.metadata.name).toBe(CLASSIC_TEMPLATE_METADATA.name);
-    expect(classicModule?.metadata.version).toBe(CLASSIC_TEMPLATE_DEFINITION.metadata.version);
-    expect(classicModule?.gallery.categoryId).toBe('signature');
+  it('includes the built-in template modules with matching metadata', () => {
+    MODULE_EXPECTATIONS.forEach(({ id, metadata, definition }) => {
+      const module = TEMPLATE_MODULES.find((entry) => entry.id === id);
+      expect(module).toBeDefined();
+      expect(module?.metadata.name).toBe(metadata.name);
+      expect(module?.metadata.version).toBe(definition.metadata.version);
+      expect(module?.gallery.categoryId).toBe('signature');
+    });
   });
 
   it('provides a preview style aligned with the registry defaults', () => {
-    const classicModule = TEMPLATE_MODULES.find((module) => module.id === CLASSIC_TEMPLATE_ID);
-    const previewStyle = classicModule?.previewStyle;
-    const definitionStyle = CLASSIC_TEMPLATE_DEFINITION.defaults.createStyle();
-    expect(previewStyle).toEqual(definitionStyle);
+    MODULE_EXPECTATIONS.forEach(({ id, definition }) => {
+      const module = TEMPLATE_MODULES.find((entry) => entry.id === id);
+      const previewStyle = module?.previewStyle;
+      const definitionStyle = definition.defaults.createStyle();
+      expect(previewStyle).toEqual(definitionStyle);
+    });
   });
 
   it('maps every module to a declared gallery category', () => {

--- a/templates/femmeFriday/index.ts
+++ b/templates/femmeFriday/index.ts
@@ -1,0 +1,63 @@
+import type { Style } from '../../types';
+import type { TemplateModule } from '../types';
+import type { TemplateMetadata } from '../../lib/templates/registry';
+
+export const FEMME_FRIDAY_TEMPLATE_ID = 'femme-friday' as const;
+
+export const FEMME_FRIDAY_TEMPLATE_METADATA: TemplateMetadata = {
+  name: 'Femme Friday',
+  description: 'Gradient story inspired by Femme NJ with a soft timeline vibe for boutique studios.',
+  category: 'story',
+  tags: ['story', 'timeline', 'gradient'],
+  version: '1.0.0',
+  createdBy: 'studiogram',
+};
+
+export const FEMME_FRIDAY_TEMPLATE_BASE_STYLE: Style = {
+  fontFamily: "'Poppins', sans-serif",
+  heading: 'CLASS SCHEDULE',
+  subtitle: 'Friday',
+  footer: '@femme.nj',
+  backgroundColor: '#3b0a55',
+  cardBackgroundColor: 'rgba(255, 255, 255, 0.08)',
+  textColorPrimary: '#FDF2F8',
+  textColorSecondary: '#F9A8D4',
+  accent: '#F472B6',
+  bgImage: '',
+  bgFit: 'cover',
+  bgBlur: 0,
+  bgPosition: '50% 50%',
+  logoUrl: '',
+  logoPosition: 'bottom-center',
+  logoPadding: 48,
+  logoSize: 100,
+  overlayColor: 'rgba(59, 10, 85, 0.25)',
+  headingWeight: '700',
+  bodySize: 34,
+  cornerRadius: '2xl',
+  dividerStyle: 'none',
+  accentLines: false,
+  footerBar: false,
+  supportsBackgroundImage: true,
+  showHeading: true,
+  showSubtitle: true,
+  showSchedule: true,
+  showFooter: true,
+  showScheduleDate: false,
+  cardCornerRadius: 28,
+  spacing: 'spacious',
+  layoutStyle: 'list',
+};
+
+export const FEMME_FRIDAY_TEMPLATE_MODULE: TemplateModule = {
+  id: FEMME_FRIDAY_TEMPLATE_ID,
+  metadata: FEMME_FRIDAY_TEMPLATE_METADATA,
+  previewStyle: { ...FEMME_FRIDAY_TEMPLATE_BASE_STYLE },
+  gallery: {
+    categoryId: 'signature',
+    accentColor: FEMME_FRIDAY_TEMPLATE_BASE_STYLE.accent,
+    tagline: 'Pink gradient story layout with glowing timeline accents.',
+    features: ['High-contrast typography', 'Soft neon gradient', 'Timeline-inspired spacing'],
+    styleTags: ['gradient', 'timeline', 'boutique'],
+  },
+};

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -1,6 +1,17 @@
 import type { TemplateId } from '../types';
 import type { TemplateGalleryCategory, TemplateModule } from './types';
-import { CLASSIC_TEMPLATE_MODULE, CLASSIC_TEMPLATE_ID, CLASSIC_TEMPLATE_BASE_STYLE, CLASSIC_TEMPLATE_METADATA } from './classic';
+import {
+  CLASSIC_TEMPLATE_MODULE,
+  CLASSIC_TEMPLATE_ID,
+  CLASSIC_TEMPLATE_BASE_STYLE,
+  CLASSIC_TEMPLATE_METADATA,
+} from './classic';
+import {
+  FEMME_FRIDAY_TEMPLATE_MODULE,
+  FEMME_FRIDAY_TEMPLATE_ID,
+  FEMME_FRIDAY_TEMPLATE_BASE_STYLE,
+  FEMME_FRIDAY_TEMPLATE_METADATA,
+} from './femmeFriday';
 
 export const TEMPLATE_GALLERY_CATEGORIES: TemplateGalleryCategory[] = [
   {
@@ -11,7 +22,7 @@ export const TEMPLATE_GALLERY_CATEGORIES: TemplateGalleryCategory[] = [
   },
 ];
 
-export const TEMPLATE_MODULES: TemplateModule[] = [CLASSIC_TEMPLATE_MODULE];
+export const TEMPLATE_MODULES: TemplateModule[] = [CLASSIC_TEMPLATE_MODULE, FEMME_FRIDAY_TEMPLATE_MODULE];
 
 export const BUILT_IN_TEMPLATE_IDS = new Set<TemplateId>(
   TEMPLATE_MODULES.map((module) => module.id),
@@ -20,6 +31,15 @@ export const BUILT_IN_TEMPLATE_IDS = new Set<TemplateId>(
 export const getTemplateModule = (templateId: TemplateId): TemplateModule | null =>
   TEMPLATE_MODULES.find((module) => module.id === templateId) ?? null;
 
-export { CLASSIC_TEMPLATE_ID, CLASSIC_TEMPLATE_BASE_STYLE, CLASSIC_TEMPLATE_METADATA } from './classic';
+export {
+  CLASSIC_TEMPLATE_ID,
+  CLASSIC_TEMPLATE_BASE_STYLE,
+  CLASSIC_TEMPLATE_METADATA,
+} from './classic';
+export {
+  FEMME_FRIDAY_TEMPLATE_ID,
+  FEMME_FRIDAY_TEMPLATE_BASE_STYLE,
+  FEMME_FRIDAY_TEMPLATE_METADATA,
+} from './femmeFriday';
 export type { TemplateModule, TemplateGalleryCategory } from './types';
 export type { TemplateGalleryCategoryId } from './types';


### PR DESCRIPTION
## Summary
- add the Femme Friday template module with base styling and gallery metadata
- register the template with the runtime registry and default configs
- expand template module tests to cover all built-in templates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6904a1eb3cdc83278c661d0c814a5564